### PR TITLE
Fix KUL packages according to changes in the git repos

### DIFF
--- a/esrocos.osdeps
+++ b/esrocos.osdeps
@@ -19,7 +19,7 @@ ant:
 
 lua:
     debian:
-        default: [lua5.2, luarocks, liblua5.2-dev]
+        default: [lua5.2, liblua5.2-dev]
 
 python3-pyside:
     debian:

--- a/packages.autobuild
+++ b/packages.autobuild
@@ -26,11 +26,9 @@ cmake_package "gui/vizkit3d_taste" do |pkg|
     Esrocos.set_taste_package(pkg)
 end
 
-cmake_package "control/ilk-compiler" do |pkg|
-   Autoproj.env_add("LUA_PATH", pkg.srcdir + "/?.lua")
+cmake_package "control/kin-gen" do |pkg|
+   Autoproj.env_add("KIN_GEN_ROOT", pkg.srcdir)
 end
-
-cmake_package "control/ilk-generator"
 
 cmake_package "tools/libpus" do |pkg|
     Esrocos.set_taste_package(pkg)

--- a/source.yml
+++ b/source.yml
@@ -67,13 +67,10 @@ version_control:
           github: ESROCOS/gui-vizkit3d_taste
           branch: master
 
-        - control/ilk-compiler:
-          github: ESROCOS/ilk-compiler.git
-          branch: dev-autoproj
-
-        - control/ilk-generator:
-          github: ESROCOS/ilk-generator.git
-          branch: dev-autoproj
+        # The kinematics code generator
+        - control/kin-gen:
+          github: ESROCOS/kin-gen
+          branch: autoproj
           
         - tools/libpus:
           github: ESROCOS/tools-libpus


### PR DESCRIPTION
This merge request consists of one single commit, on top of master (at the moment)
Please review and merge to master, if possible.

Here is the comment in the commit:

There is now a single repository 'kin-gen' that contains the
ilk-generator and ilk-compiler as submodules. Thus, we only
need to integrate 'kin-gen' in the esrocos build system.

The branch of the project is set to 'autoproj', as that is the
one containing the required CMakeLists and manifest.

We removed 'luarocks' from the list associated with the 'lua'
dependency, since luarocks should be installed by hand; the package
manager version might not match the Lua interpreter version.